### PR TITLE
Catalogue Bookmark Bug

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCataloguePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCataloguePresenter.kt
@@ -364,12 +364,7 @@ open class BrowseCataloguePresenter(
      */
     fun updateMangaCategories(manga: Manga, selectedCategories: List<Category>) {
         if (!selectedCategories.isEmpty()) {
-            if (!manga.favorite)
-                changeMangaFavorite(manga)
-
             moveMangaToCategories(manga, selectedCategories.filter { it.id != 0 })
-        } else {
-            changeMangaFavorite(manga)
         }
     }
 


### PR DESCRIPTION
Bug description

1. Have at least one library category and have default category to `always ask`
2. Long tap a manga from catalogue to add to library
3. Do not select a category from the `Move to Category` dialog
4. Click `ok`
5. Manga is removed from library