### PR TITLE
fix filtered head item count not updating on back

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionController.kt
@@ -83,7 +83,8 @@ open class ExtensionController : NucleusController<ExtensionPresenter>(),
         searchView.queryTextChanges()
                 .skip(1)
                 .subscribeUntilDestroy {
-                    filterExtensions(it.toString())
+                    adapter?.searchText = it.toString()
+                    setExtensions()
                 }
 
         ext_swipe_refresh.refreshes().subscribeUntilDestroy {
@@ -158,13 +159,9 @@ open class ExtensionController : NucleusController<ExtensionPresenter>(),
                 .showDialog(router)
     }
 
-    fun setExtensions(extensions: List<ExtensionItem>) {
+    fun setExtensions() {
         ext_swipe_refresh?.isRefreshing = false
-        adapter?.updateDataSet(extensions)
-    }
-
-    private fun filterExtensions(query: String) {
-        adapter?.updateDataSet(presenter.getFilteredExtensions(query))
+        adapter?.updateDataSet(presenter.getFilteredExtensions(adapter?.searchText ?: ""))
     }
 
     fun updateInstallStep(item: ExtensionItem) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionPresenter.kt
@@ -47,8 +47,8 @@ open class ExtensionPresenter(
                 .debounce(100, TimeUnit.MILLISECONDS)
                 .map(::toItems)
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeLatestCache({view, items ->
-                    view.setExtensions(items)
+                .subscribeLatestCache({view, _ ->
+                    view.setExtensions()
                 })
     }
 


### PR DESCRIPTION
**Scenario:**
1. Perform filter on extensions while ensuring there is at least one installed extension visible
2. click on details of an installed extension
3. press back
4. item count in language group headers are not updated

**Cause:**
Filter mutates group headers. Search queries are cleared out on navigating away from view, but filter is not performed. On back from extension details, `setExtensions` is thus called with group headers still retaining the values set in the last filter.

