### PR TITLE
Add Option to Use Source Order for Invididual Manga

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
@@ -45,6 +45,10 @@ interface Manga : SManga {
         get() = chapter_flags and BOOKMARKED_MASK
         set(filter) = setFlags(filter, BOOKMARKED_MASK)
 
+    var order: Int
+        get() = chapter_flags and ORDER_MASK
+        set(order) = setFlags(order, ORDER_MASK)
+
     companion object {
 
         const val SORT_DESC = 0x00000000
@@ -65,6 +69,10 @@ interface Manga : SManga {
         const val SHOW_BOOKMARKED = 0x00000020
         const val SHOW_NOT_BOOKMARKED = 0x00000040
         const val BOOKMARKED_MASK = 0x00000060
+
+        const val ORDER_DEFAULT = 0x00000000
+        const val ORDER_SOURCE = 0x00000100
+        const val ORDER_MASK = 0x00000100
 
         const val DISPLAY_NAME = 0x00000000
         const val DISPLAY_NUMBER = 0x00100000

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
@@ -133,12 +133,14 @@ class ChaptersController : NucleusController<ChaptersPresenter>(),
         val menuFilterUnread = menu.findItem(R.id.action_filter_unread)
         val menuFilterDownloaded = menu.findItem(R.id.action_filter_downloaded)
         val menuFilterBookmarked = menu.findItem(R.id.action_filter_bookmarked)
+        val menuSourceOrder = menu.findItem(R.id.action_source_order)
 
         // Set correct checkbox values.
         menuFilterRead.isChecked = presenter.onlyRead()
         menuFilterUnread.isChecked = presenter.onlyUnread()
         menuFilterDownloaded.isChecked = presenter.onlyDownloaded()
         menuFilterBookmarked.isChecked = presenter.onlyBookmarked()
+        menuSourceOrder.isChecked = presenter.useSourceOrder()
 
         if (presenter.onlyRead())
             //Disable unread filter option if read filter is enabled.
@@ -156,6 +158,10 @@ class ChaptersController : NucleusController<ChaptersPresenter>(),
             R.id.download_custom, R.id.download_unread, R.id.download_all
             -> downloadChapters(item.itemId)
 
+            R.id.action_source_order -> {
+                item.isChecked = !item.isChecked
+                presenter.setSourceOrder(item.isChecked)
+            }
             R.id.action_filter_unread -> {
                 item.isChecked = !item.isChecked
                 presenter.setUnreadFilter(item.isChecked)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
@@ -186,7 +186,8 @@ class ChaptersPresenter(
         if (onlyBookmarked()) {
             observable = observable.filter { it.bookmark }
         }
-        val sortFunction: (Chapter, Chapter) -> Int = when (preferences.optimizeChapterOrder()) {
+
+        val sortFunction: (Chapter, Chapter) -> Int = when (manga.order == Manga.ORDER_DEFAULT && preferences.optimizeChapterOrder()) {
             true -> when (sortDescending()) {
                 true -> { c1, c2 -> c2.chapter_number.compareTo(c1.chapter_number) }
                 false -> { c1, c2 -> c1.chapter_number.compareTo(c2.chapter_number) }
@@ -371,6 +372,16 @@ class ChaptersPresenter(
     }
 
     /**
+     * Sets the chapter order and requests an UI update.
+     * @param useSourceOrder whether or not to load chapters by source order
+     */
+    fun setSourceOrder(useSourceOrder: Boolean) {
+        manga.order = if (useSourceOrder) Manga.ORDER_SOURCE else Manga.ORDER_DEFAULT
+        db.updateFlags(manga).executeAsBlocking()
+        refreshChapters()
+    }
+
+    /**
      * Whether the display only downloaded filter is enabled.
      */
     fun onlyDownloaded(): Boolean {
@@ -396,6 +407,10 @@ class ChaptersPresenter(
      */
     fun onlyRead(): Boolean {
         return manga.readFilter == Manga.SHOW_READ
+    }
+
+    fun useSourceOrder(): Boolean {
+        return manga.order == Manga.ORDER_SOURCE
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -100,7 +100,7 @@ class ReaderPresenter(
                     dbChapters
                 }
 
-        when (preferences.optimizeChapterOrder()) {
+        when (manga.order == Manga.ORDER_DEFAULT && preferences.optimizeChapterOrder()) {
             true -> ChapterLoadByNumber.get(chaptersForReader, selectedChapter)
             false -> ChapterLoadBySource.get(chaptersForReader)
         }.map(::ReaderChapter)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recently_read/RecentlyReadPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recently_read/RecentlyReadPresenter.kt
@@ -90,7 +90,7 @@ class RecentlyReadPresenter(
 
         val allChapters = db.getChapters(manga).executeAsBlocking()
 
-        return when (preferences.optimizeChapterOrder()) {
+        return when (manga.order == Manga.ORDER_DEFAULT && preferences.optimizeChapterOrder()) {
             true -> ChapterLoadByNumber.getNextChapter(allChapters, chapter)
             false -> ChapterLoadBySource.getNextChapter(allChapters, chapter)
         }

--- a/app/src/main/res/menu/chapters.xml
+++ b/app/src/main/res/menu/chapters.xml
@@ -66,4 +66,10 @@
                 android:title="@string/download_all" />
         </menu>
     </item>
+
+    <item
+        android:id="@+id/action_source_order"
+        android:title="@string/source_order"
+        android:checkable="true"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -286,9 +286,6 @@
     <string name="fetch_chapters_error">حدث خطأ أثناء جلب الفصول</string>
     <string name="show_title">عرض العنوان</string>
     <string name="show_chapter_number">عرض رقم الفصل</string>
-    <string name="sorting_mode">كيفية الفرز</string>
-    <string name="sort_by_source">حسب المصدر</string>
-    <string name="sort_by_number">حسب رقم الفصل</string>
     <string name="manga_download">تحميل</string>
     <string name="download_1">تحميل الفصل التالي</string>
     <string name="download_5">تحميل الفصول الخمسة التالية</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -239,9 +239,6 @@
     <string name="fetch_chapters_error">Възникна грешка при показването на главите</string>
     <string name="show_title">Покажи заглавие</string>
     <string name="show_chapter_number">Показвай номера на главата</string>
-    <string name="sorting_mode">Сортиране</string>
-    <string name="sort_by_source">По източник</string>
-    <string name="sort_by_number">По ред на главите</string>
     <string name="manga_download">Изтегли</string>
     <string name="download_1">Изтегли следващата глава</string>
     <string name="download_5">Изтегли следващите 5 глави</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -286,9 +286,6 @@
     <string name="fetch_chapters_error">অধ্যায়গুলো নির্বাচন করতে যেয়ে ত্রুটি দেখা দিয়েছে</string>
     <string name="show_title">শিরোনাম দেখান</string>
     <string name="show_chapter_number">অধ্যায় নাম্বার দেখান</string>
-    <string name="sorting_mode">সাজানোর রূপ</string>
-    <string name="sort_by_source">উৎস অনুযায়ী</string>
-    <string name="sort_by_number">অধ্যায়ের নাম্বার অনুযায়ী</string>
     <string name="manga_download">ডাউনলোড</string>
     <string name="download_1">পরবর্তী অধ্যায় ডাউনলোড করুন</string>
     <string name="download_5">পরবর্তী ৫ অধ্যায় ডাউনলোড করুন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -325,9 +325,6 @@
     <string name="fetch_chapters_error">S\'ha produït un error en obtenir els capítols</string>
     <string name="show_title">Mostra el títol</string>
     <string name="show_chapter_number">Mostra el número del capítol</string>
-    <string name="sorting_mode">Mode d\'ordenació</string>
-    <string name="sort_by_source">Per font</string>
-    <string name="sort_by_number">Per número de capítol</string>
     <string name="manga_download">Descarrega</string>
     <string name="custom_download">Descarrega\'n una quantitat personalitzada</string>
     <string name="custom_hint">quantitat</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -159,7 +159,6 @@
     <string name="chapter_downloading_progress">Stahování (%1$d/%2$d)</string>
     <string name="chapter_error">Chyba</string>
     <string name="chapter_paused">Pozastaveno</string>
-    <string name="sort_by_source">Podle zdroje</string>
     <string name="manga_download">Stáhnout</string>
     <string name="download_1">Stáhnout další kapitolu</string>
     <string name="download_5">Stáhnout dalších 5 kapitol</string>
@@ -360,8 +359,6 @@
     <string name="copied_to_clipboard">%1$s zkopírováno do schránky</string>
     <string name="chapter_queued">Ve frontě</string>
     <string name="fetch_chapters_error">Chyba při načítání kapitol</string>
-    <string name="sorting_mode">Režim seřazení</string>
-    <string name="sort_by_number">Podle čísla kapitoly</string>
     <string name="custom_download">Stažení vlastního počtu</string>
     <string name="custom_hint">počet</string>
     <string name="manga_tracking_tab">Sledování</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -275,9 +275,6 @@
     <string name="fetch_chapters_error">Fehler beim Abrufen der Kapitel</string>
     <string name="show_title">Titel anzeigen</string>
     <string name="show_chapter_number">Kaptielnummer anzeigen</string>
-    <string name="sorting_mode">Sortiere nach</string>
-    <string name="sort_by_source">Quelle</string>
-    <string name="sort_by_number">Kapitelnummer</string>
     <string name="manga_download">Herunterladen</string>
     <string name="download_1">Nächstes Kapitel herunterladen</string>
     <string name="download_5">Die nächsten 5 Kapitel herunterladen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -326,9 +326,6 @@
     <string name="fetch_chapters_error">Σφάλμα κατά την ανάκτηση κεφαλαίων</string>
     <string name="show_title">Εμφάνιση τίτλου</string>
     <string name="show_chapter_number">Εμφάνιση αριθμού κεφαλαίου</string>
-    <string name="sorting_mode">Λειτουργία ταξινόμησης</string>
-    <string name="sort_by_source">Με βάση την πηγή</string>
-    <string name="sort_by_number">Ανά αριθμό κεφαλαίου</string>
     <string name="manga_download">Λήψη</string>
     <string name="custom_download">Λήψη προσαρμοσμένου ποσού</string>
     <string name="custom_hint">ποσό</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -191,9 +191,6 @@
     <string name="fetch_chapters_error">Error al obtener capítulos</string>
     <string name="show_title">Mostrar título</string>
     <string name="show_chapter_number">Mostrar número de capítulo</string>
-    <string name="sorting_mode">Ordenado de capítulos</string>
-    <string name="sort_by_source">Por fuente</string>
-    <string name="sort_by_number">Por número de capítulo</string>
     <string name="manga_download">Descargar</string>
     <string name="download_1">Descargar siguiente capítulo</string>
     <string name="download_5">Descargar siguientes 5 capítulos</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -373,9 +373,6 @@
     <string name="fetch_chapters_error">Virhe hakiessa lukuja</string>
     <string name="show_title">Näytä nimike</string>
     <string name="show_chapter_number">Näytä luvun numero</string>
-    <string name="sorting_mode">Lajittelutila</string>
-    <string name="sort_by_source">Lähteen mukaan</string>
-    <string name="sort_by_number">Luvun numeron mukaan</string>
     <string name="manga_download">Lataa</string>
     <string name="confirm_delete_chapters">Oletko varma että haluat poistaa valitut luvut\?</string>
     <string name="reading">Luettavana</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -226,8 +226,6 @@
     <string name="fetch_chapters_error">Une erreur est survenue en récupérant les chapitres</string>
     <string name="show_title">Afficher le titre</string>
     <string name="show_chapter_number">Afficher le numéro de chapitre</string>
-    <string name="sorting_mode">Mode de tri</string>
-    <string name="sort_by_number">Par numéro de chapitre</string>
     <string name="manga_download">Télécharger</string>
     <string name="download_1">Télécharger le chapitre suivant</string>
     <string name="download_5">Télécharger les 5 prochains chapitres</string>
@@ -329,7 +327,6 @@
     <string name="pref_clear_chapter_cache">Effacer le cache des chapitres</string>
     <string name="pref_remove_after_marked_as_read">Supprimer quand marqué comme lu</string>
     <string name="rounded_icon">Icône ronde</string>
-    <string name="sort_by_source">Par source</string>
     <string name="system_default">Par défaut système</string>
     <string name="updating_category">Mise à jour de la catégorie</string>
     <string name="no_more_results">Pas d\'autres résultats</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -287,9 +287,6 @@
     <string name="fetch_chapters_error">अध्याय लाने के दौरान त्रुटि</string>
     <string name="show_title">शीर्षक दिखाओ</string>
     <string name="show_chapter_number">अध्याय संख्या दिखाएं</string>
-    <string name="sorting_mode">छंटनी मोड</string>
-    <string name="sort_by_source">स्रोत से</string>
-    <string name="sort_by_number">अध्याय संख्या से</string>
     <string name="manga_download">डाउनलोड</string>
     <string name="download_1">अगले अध्याय डाउनलोड करें</string>
     <string name="download_5">अगले ५ अध्याय डाउनलोड करें</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -277,9 +277,6 @@
     <string name="fetch_chapters_error">Eror saat mengambil bab dari server</string>
     <string name="show_title">Perlihatkan judul</string>
     <string name="show_chapter_number">Perlihatkan nomor bab</string>
-    <string name="sorting_mode">Urutkan menurut</string>
-    <string name="sort_by_source">Sumber</string>
-    <string name="sort_by_number">Nomor bab</string>
     <string name="manga_download">Unduh</string>
     <string name="download_1">Unduh bab berikutnya</string>
     <string name="download_5">Unduh 5 bab berikutnya</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -233,9 +233,6 @@
     <string name="fetch_chapters_error">Errore durante il recupero dei capitoli</string>
     <string name="show_title">Mostra titolo</string>
     <string name="show_chapter_number">Mostra numero del capitolo</string>
-    <string name="sorting_mode">Modalità di ordinamento</string>
-    <string name="sort_by_source">Per fonte</string>
-    <string name="sort_by_number">Per numero di capitolo</string>
     <string name="manga_download">Scarica</string>
     <string name="download_1">Scarica il prossimo capitolo</string>
     <string name="download_5">Scarica i prossimi 5 capitoli</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -266,9 +266,6 @@
     <string name="chapter_error">오류</string>
     <string name="chapter_paused">일시중지됨</string>
     <string name="show_chapter_number">챕터 번호 표시</string>
-    <string name="sorting_mode">정렬 모드</string>
-    <string name="sort_by_source">소스 기준</string>
-    <string name="sort_by_number">챕터 번호 기준</string>
     <string name="manga_download">다운로드</string>
     <string name="download_1">다음 챕터 다운로드</string>
     <string name="download_5">다음 5 챕터 다운로드</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -286,9 +286,6 @@
     <string name="fetch_chapters_error">Ralat ketika mendapatkan bab</string>
     <string name="show_title">Perlihatkan tajuk</string>
     <string name="show_chapter_number">Perlihatkan nombor bab</string>
-    <string name="sorting_mode">Mod susunan</string>
-    <string name="sort_by_source">Mengikut sumber</string>
-    <string name="sort_by_number">Mengikut nombor bab</string>
     <string name="manga_download">Muat turun</string>
     <string name="download_1">Muat turun bab seterusnya</string>
     <string name="download_5">Muat turun 5 bab seterusnya</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -317,9 +317,6 @@
     <string name="fetch_chapters_error">Feil under innhenting av kapittel</string>
     <string name="show_title">Vis tittel</string>
     <string name="show_chapter_number">Vis kapittelnummer</string>
-    <string name="sorting_mode">Sorteringsmodus</string>
-    <string name="sort_by_source">Etter kilde</string>
-    <string name="sort_by_number">Etter kapittelnummer</string>
     <string name="manga_download">Last ned</string>
     <string name="custom_download">Last ned egendefinert mengde</string>
     <string name="custom_hint">mengde</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -208,9 +208,6 @@
     <string name="chapter_paused">Gepauzeerd</string>
     <string name="show_title">Toon titel</string>
     <string name="show_chapter_number">Toon hoofdstuknummer</string>
-    <string name="sorting_mode">Sorteermodus</string>
-    <string name="sort_by_source">Op bron</string>
-    <string name="sort_by_number">Op hoofdstuknummer</string>
     <string name="manga_download">Downloaden</string>
     <string name="download_1">Download het volgende hoofdstuk</string>
     <string name="download_5">Download de volgende 5 hoofdstukken</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -325,9 +325,6 @@ Nie znaleziono źródła %1$s</string>
     <string name="chapter_downloading">Pobieranie</string>
     <string name="chapter_downloading_progress">Pobieranie (%1$d/%2$d)</string>
     <string name="fetch_chapters_error">Błąd przy pobieraniu listy rozdziałów</string>
-    <string name="sorting_mode">Tryb sortowania</string>
-    <string name="sort_by_source">Według źródła</string>
-    <string name="sort_by_number">Według numeru rozdziału</string>
     <string name="manga_tracking_tab">Śledzenie</string>
     <string name="status">Status</string>
     <string name="snack_categories_deleted">Kategorie usunięte</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -276,9 +276,6 @@ Além disso, verifique se as fontes que requerem uma conta foram configuradas co
     <string name="fetch_chapters_error">Erro ao obter capítulos</string>
     <string name="show_title">Mostrar título</string>
     <string name="show_chapter_number">Mostrar número do capítulo</string>
-    <string name="sorting_mode">Modo de classificação</string>
-    <string name="sort_by_source">Pela fonte</string>
-    <string name="sort_by_number">Pelo número do capítulo</string>
     <string name="manga_download">Fazer download</string>
     <string name="download_1">Fazer download do próximo capítulo</string>
     <string name="download_5">Fazer download dos próximos 5 capítulos</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -200,9 +200,6 @@
     <string name="fetch_chapters_error">Erro ao obter capítulos</string>
     <string name="show_title">Mostrar título</string>
     <string name="show_chapter_number">Mostrar número de capítulo</string>
-    <string name="sorting_mode">Modo de organização</string>
-    <string name="sort_by_source">Por fonte</string>
-    <string name="sort_by_number">Por número de capítulo</string>
     <string name="manga_download">Transferir</string>
     <string name="download_1">Transferir próximo capítulo</string>
     <string name="download_5">Transferir próximos 5 capítulos</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -324,9 +324,6 @@
     <string name="fetch_chapters_error">Eroare în aducerea capitolelor</string>
     <string name="show_title">Arată titlul</string>
     <string name="show_chapter_number">Arată numărul capitolului</string>
-    <string name="sorting_mode">Mod de sortare</string>
-    <string name="sort_by_source">După sursă</string>
-    <string name="sort_by_number">După numărul de capitole</string>
     <string name="manga_download">Descarcă</string>
     <string name="custom_download">Descarcă cantitate personalizată</string>
     <string name="custom_hint">cantitate</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -254,9 +254,6 @@
     <string name="show_password">Показывать пароль</string>
     <string name="show_title">Показывать название</string>
     <string name="snack_add_to_library">Добавить мангу в библиотеку?</string>
-    <string name="sort_by_number">По номеру главы</string>
-    <string name="sort_by_source">По каталогу</string>
-    <string name="sorting_mode">Метод сортировки</string>
     <string name="source_requires_login">Этот каталог требует авторизации</string>
     <string name="square_icon">Квадратная иконка</string>
     <string name="star_icon">Звездочная иконка</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -326,9 +326,6 @@
     <string name="fetch_chapters_error">Errore durante su recùperu de sos capìtulos</string>
     <string name="show_title">Ammustra su tìtulu</string>
     <string name="show_chapter_number">Ammustra su nùmeru de su capìtulu</string>
-    <string name="sorting_mode">Modalidade de ordinamentu</string>
-    <string name="sort_by_source">Pro mitza</string>
-    <string name="sort_by_number">Pro nùmeru de capìtulu</string>
     <string name="manga_download">Iscàrriga</string>
     <string name="custom_download">Iscàrriga una cantidade personalizada</string>
     <string name="custom_hint">cantidade</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -326,10 +326,7 @@
     <string name="fetch_chapters_error">Greška tokom dobijanja poglavlja</string>
     <string name="show_title">Prikaži naslov</string>
     <string name="show_chapter_number">Prikaži broj poglavlja</string>
-    <string name="sorting_mode">Model sortiranja</string>
     <string name="pref_read_with_long_tap">Dialog kod dugog pritiska</string>
-    <string name="sort_by_source">Prema izvoru</string>
-    <string name="sort_by_number">Prema broju poglavlja</string>
     <string name="manga_download">Preuzmi</string>
     <string name="custom_download">Preuzmi određen broj</string>
     <string name="custom_hint">količina</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -325,9 +325,6 @@
     <string name="fetch_chapters_error">Fel vid hämtning av kapitel</string>
     <string name="show_title">Visa titel</string>
     <string name="show_chapter_number">Visa kapitelnummer</string>
-    <string name="sorting_mode">Sorteringsläge</string>
-    <string name="sort_by_source">Efter källa</string>
-    <string name="sort_by_number">Efter kapitelnummer</string>
     <string name="manga_download">Ladda ner</string>
     <string name="custom_download">Ladda ner anpassat belopp</string>
     <string name="custom_hint">Belopp</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -325,9 +325,6 @@
     <string name="fetch_chapters_error">เกิดข้อผิดพลาดขณะตรวจสอบจำนวนบท</string>
     <string name="show_title">แสดงชื่อเรื่อง</string>
     <string name="show_chapter_number">แสดงหมายเลขบท</string>
-    <string name="sorting_mode">โหมดการเรียงลำดับ</string>
-    <string name="sort_by_source">ตามแหล่งที่มา</string>
-    <string name="sort_by_number">ตามหมายเลขบท</string>
     <string name="manga_download">ดาวน์โหลด</string>
     <string name="custom_download">จำนวนดาวน์โหลดที่กำหนดเอง</string>
     <string name="custom_hint">จำนวน</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -339,9 +339,6 @@
     <string name="fetch_chapters_error">Nagka-error habang kinukuha ang mga kabanata</string>
     <string name="show_title">Ipakita ang pamagat</string>
     <string name="show_chapter_number">Ipakita ang bilang ng kabanata</string>
-    <string name="sorting_mode">Paraan ng pag-aayos</string>
-    <string name="sort_by_source">Base sa source</string>
-    <string name="sort_by_number">Base sa bilang ng kabanata</string>
     <string name="manga_download">I-download</string>
     <string name="custom_download">I-download ang custom na rami</string>
     <string name="custom_hint">dami</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -324,9 +324,6 @@
     <string name="fetch_chapters_error">Bölümler alınırken hata</string>
     <string name="show_title">Başlığı göster</string>
     <string name="show_chapter_number">Bölüm numarasını göster</string>
-    <string name="sorting_mode">Sıralama kipi</string>
-    <string name="sort_by_source">Kaynağa göre</string>
-    <string name="sort_by_number">Bölüm numarasına göre</string>
     <string name="manga_download">İndir</string>
     <string name="custom_download">Özel toplamda indir</string>
     <string name="custom_hint">Toplam</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -325,9 +325,6 @@
     <string name="fetch_chapters_error">Помилка при видобуванні глав</string>
     <string name="show_title">Показувати назву</string>
     <string name="show_chapter_number">Показувати номер глави</string>
-    <string name="sorting_mode">Метод сортування</string>
-    <string name="sort_by_source">За каталогом</string>
-    <string name="sort_by_number">За номером глави</string>
     <string name="manga_download">Завантажити</string>
     <string name="custom_download">Завантажити певну кількість</string>
     <string name="custom_hint">кількість</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -240,9 +240,6 @@
     <string name="fetch_chapters_error">Lỗi khi lấy dữ liệu các chương</string>
     <string name="show_title">Hiện tiêu đề</string>
     <string name="show_chapter_number">Hiện số chương</string>
-    <string name="sorting_mode">Sắp xếp</string>
-    <string name="sort_by_source">Theo nguồn truyện</string>
-    <string name="sort_by_number">Theo số chương</string>
     <string name="manga_download">Tải xuống</string>
     <string name="download_1">Tải chương kế</string>
     <string name="download_5">Tải 5 chương kế tiếp</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -324,9 +324,6 @@
     <string name="fetch_chapters_error">获取章节失败</string>
     <string name="show_title">显示标题</string>
     <string name="show_chapter_number">显示章节数</string>
-    <string name="sorting_mode">排序模式</string>
-    <string name="sort_by_source">按类型</string>
-    <string name="sort_by_number">按章节</string>
     <string name="manga_download">下载</string>
     <string name="custom_download">自定义下载数量</string>
     <string name="custom_hint">数量</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -331,9 +331,6 @@
     <string name="fetch_chapters_error">章節取得失敗</string>
     <string name="show_title">顯示標題</string>
     <string name="show_chapter_number">顯示章節</string>
-    <string name="sorting_mode">排序依據</string>
-    <string name="sort_by_source">遵循來源</string>
-    <string name="sort_by_number">按照章節</string>
     <string name="download_1">下載後一章</string>
     <string name="download_5">下載後五章</string>
     <string name="download_10">下載後十章</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,9 +391,7 @@
     <string name="fetch_chapters_error">Could not fetch chapters</string>
     <string name="show_title">Show title</string>
     <string name="show_chapter_number">Show chapter number</string>
-    <string name="sorting_mode">Sorting mode</string>
-    <string name="sort_by_source">By source</string>
-    <string name="sort_by_number">By chapter number</string>
+    <string name="source_order">Use Source Order</string>
     <string name="manga_download">Download</string>
     <string name="custom_download">Download custom amount</string>
     <string name="custom_hint">amount</string>


### PR DESCRIPTION
allow "optimize chapter order" setting to be overridden on a per manga basis